### PR TITLE
Fixing _input_terminator bug in parse_gate.py

### DIFF
--- a/crate_anon/nlp_manager/parse_gate.py
+++ b/crate_anon/nlp_manager/parse_gate.py
@@ -146,7 +146,7 @@ class Gate(BaseNlpParser):
                 ProcessorConfigKeys.MAX_EXTERNAL_PROG_USES,
                 default=0)
             self._input_terminator = self._cfgsection.opt_str(
-                self._sectionname, ProcessorConfigKeys.INPUT_TERMINATOR,
+                ProcessorConfigKeys.INPUT_TERMINATOR,
                 required=True)
             self._output_terminator = self._cfgsection.opt_str(
                 ProcessorConfigKeys.OUTPUT_TERMINATOR,


### PR DESCRIPTION
Broken in commit: 93e61d154722626c3e8ce198ea4d7d45d68c3763

Error message: 'AssertionError: required and default are incompatible'