### PR TITLE
Handle failure to insert row in destination table during NLP

### DIFF
--- a/crate_anon/nlp_manager/cloud_request.py
+++ b/crate_anon/nlp_manager/cloud_request.py
@@ -36,7 +36,7 @@ import logging
 import sys
 from typing import Any, Dict, List, Tuple, Generator, Optional, TYPE_CHECKING
 import time
-from sqlalchemy.exc import DataError
+from sqlalchemy.exc import DatabaseError
 
 from cardinal_pythonlib.compression import gzip_string
 from cardinal_pythonlib.rate_limiting import rate_limited
@@ -850,7 +850,7 @@ class CloudRequestProcess(CloudRequest):
             try:
                 with MultiTimerContext(timer, TIMING_INSERT):
                     session.execute(insertquery)
-            except DataError as e:
+            except DatabaseError as e:
                 log.error(e)
                 # ... but proceed.
             self._nlpdef.notify_transaction(

--- a/crate_anon/nlp_manager/tests/cloud_request_process_tests.py
+++ b/crate_anon/nlp_manager/tests/cloud_request_process_tests.py
@@ -101,7 +101,7 @@ class CloudRequestProcessTests(TestCase):
         )
         self.assertEqual(self.mock_notify_transaction_method.call_count, 3)
 
-    def test_process_all_skips_failed_insert(self) -> None:
+    def test_process_all_handles_failed_insert(self) -> None:
         nlp_values = [
             ("output", {"fruit": "apple"}, self.mock_processor),
         ]

--- a/crate_anon/nlp_manager/tests/cloud_request_process_tests.py
+++ b/crate_anon/nlp_manager/tests/cloud_request_process_tests.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+"""
+crate_anon/nlp_manager/tests/cloud_request_process_tests.py
+
+===============================================================================
+
+    Copyright (C) 2015-2020 Rudolf Cardinal (rudolf@pobox.com).
+
+    This file is part of CRATE.
+
+    CRATE is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    CRATE is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with CRATE. If not, see <http://www.gnu.org/licenses/>.
+
+===============================================================================
+
+"""
+import logging
+import sys
+
+from sqlalchemy.exc import OperationalError
+from unittest import mock, TestCase
+
+from crate_anon.nlp_manager.cloud_request import CloudRequestProcess
+
+
+class CloudRequestProcessTests(TestCase):
+    def setUp(self) -> None:
+        self.mock_execute_method = mock.Mock()
+        self.mock_session = mock.Mock(execute=self.mock_execute_method)
+        self.mock_db = mock.Mock(session=self.mock_session)
+
+        # can't set name attribute in constructor here as it has special meaning
+        mock_column = mock.Mock()
+        mock_column.name = "fruit"  # so set it here
+
+        self.mock_values_method = mock.Mock()
+        mock_insert_object = mock.Mock(values=self.mock_values_method)
+        mock_insert_method = mock.Mock(return_value=mock_insert_object)
+        mock_sqla_table = mock.Mock(columns=[mock_column],
+                                    insert=mock_insert_method)
+        mock_get_table_method = mock.Mock(return_value=mock_sqla_table)
+        self.mock_processor = mock.Mock(
+            get_table=mock_get_table_method,
+            dest_session=self.mock_session
+        )
+
+        self.mock_notify_transaction_method = mock.Mock()
+        self.mock_nlpdef = mock.Mock(
+            notify_transaction=self.mock_notify_transaction_method
+        )
+        self.mock_nlpdef.name = "fruitdef"
+        self.process = CloudRequestProcess(nlpdef=self.mock_nlpdef)
+
+    def test_process_all_inserts_values(self) -> None:
+        nlp_values = [
+            ("output", {"fruit": "apple"}, self.mock_processor),
+            ("output", {"fruit": "banana"}, self.mock_processor),
+            ("output", {"fruit": "fig"}, self.mock_processor),
+        ]
+
+        mock_get_nlp_values_method = mock.Mock(return_value=iter(nlp_values))
+
+        with mock.patch.multiple(self.process,
+                                 get_nlp_values=mock_get_nlp_values_method):
+            self.process.process_all()
+
+        self.mock_values_method.assert_any_call({"fruit": "apple"})
+        self.mock_values_method.assert_any_call({"fruit": "banana"})
+        self.mock_values_method.assert_any_call({"fruit": "fig"})
+        self.assertEqual(self.mock_values_method.call_count, 3)
+        self.assertEqual(self.mock_execute_method.call_count, 3)
+
+        self.mock_notify_transaction_method.assert_any_call(
+            self.mock_session, n_rows=1, n_bytes=sys.getsizeof(
+                {"fruit": "apple"}
+            ),
+            force_commit=mock.ANY
+        )
+        self.mock_notify_transaction_method.assert_any_call(
+            self.mock_session, n_rows=1, n_bytes=sys.getsizeof(
+                {"fruit": "banana"}
+            ),
+            force_commit=mock.ANY
+        )
+        self.mock_notify_transaction_method.assert_any_call(
+            self.mock_session, n_rows=1, n_bytes=sys.getsizeof(
+                {"fruit": "fig"}
+            ),
+            force_commit=mock.ANY
+        )
+        self.assertEqual(self.mock_notify_transaction_method.call_count, 3)
+
+    def test_process_all_skips_failed_insert(self) -> None:
+        nlp_values = [
+            ("output", {"fruit": "apple"}, self.mock_processor),
+        ]
+
+        self.mock_execute_method.side_effect = OperationalError(
+            "Insert failed", None, None, None
+        )
+
+        mock_get_nlp_values_method = mock.Mock(return_value=iter(nlp_values))
+        with self.assertLogs(level=logging.ERROR) as logging_cm:
+            with mock.patch.multiple(self.process,
+                                     get_nlp_values=mock_get_nlp_values_method):
+                self.process.process_all()
+
+        self.mock_notify_transaction_method.assert_any_call(
+            self.mock_session, n_rows=1, n_bytes=sys.getsizeof(
+                {"fruit": "apple"}
+            ),
+            force_commit=mock.ANY
+        )
+        logger_name = "crate_anon.nlp_manager.cloud_request"
+
+        self.assertIn(
+            f"ERROR:{logger_name}",
+            logging_cm.output[0]
+        )
+        self.assertIn(
+            "Insert failed",
+            logging_cm.output[0]
+        )

--- a/crate_anon/nlp_manager/tests/nlp_parser_tests.py
+++ b/crate_anon/nlp_manager/tests/nlp_parser_tests.py
@@ -124,7 +124,7 @@ class NlpParserProcessTests(TestCase):
             logging_cm.output
         )
 
-    def test_skips_failed_insert(self) -> None:
+    def test_handles_failed_insert(self) -> None:
         self.mock_execute_method.side_effect = OperationalError(
             "Insert failed", None, None, None
         )

--- a/crate_anon/nlp_manager/tests/nlp_parser_tests.py
+++ b/crate_anon/nlp_manager/tests/nlp_parser_tests.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+"""
+crate_anon/nlp_manager/tests/nlp_manager_tests.py
+
+===============================================================================
+
+    Copyright (C) 2015-2020 Rudolf Cardinal (rudolf@pobox.com).
+
+    This file is part of CRATE.
+
+    CRATE is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    CRATE is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with CRATE. If not, see <http://www.gnu.org/licenses/>.
+
+===============================================================================
+
+"""
+import logging
+import sys
+
+from sqlalchemy.schema import Column
+from typing import Any, Dict, Generator, List, Tuple
+from unittest import mock, TestCase
+
+from crate_anon.nlp_manager.base_nlp_parser import BaseNlpParser
+
+
+class FruitParser(BaseNlpParser):
+    def test(self) -> None:
+        pass
+
+    def dest_tables_columns(self) -> Dict[str, List[Column]]:
+        return {}
+
+    def parse(self, text: str) -> Generator[Tuple[str, Dict[str, Any]],
+                                            None, None]:
+        fruits = ("apple", "banana", "cherry", "fig")
+
+        for word in text.split(" "):
+            if word.lower() in fruits:
+                yield ("output", {"fruit": word.lower()})
+
+
+class NlpParserProcessTests(TestCase):
+    def setUp(self) -> None:
+        self.parser = FruitParser(None, None)
+
+        self.mock_execute_method = mock.Mock()
+        self.mock_session = mock.Mock(execute=self.mock_execute_method)
+        self.mock_db = mock.Mock(session=self.mock_session)
+
+        # can't set name attribute in constructor here as it has special meaning
+        mock_column = mock.Mock()
+        mock_column.name = "fruit"  # so set it here
+
+        self.mock_values_method = mock.Mock()
+        mock_insert_object = mock.Mock(values=self.mock_values_method)
+        mock_insert_method = mock.Mock(return_value=mock_insert_object)
+        mock_sqla_table = mock.Mock(columns=[mock_column],
+                                    insert=mock_insert_method)
+        self.mock_get_table = mock.Mock(return_value=mock_sqla_table)
+
+        self.mock_notify_transaction_method = mock.Mock()
+        self.mock_nlpdef = mock.Mock(
+            notify_transaction=self.mock_notify_transaction_method
+        )
+        self.mock_nlpdef.name = "fruitdef"
+
+    def test_inserts_values(self) -> None:
+        with self.assertLogs(level=logging.DEBUG) as logging_cm:
+            with mock.patch.multiple(self.parser,
+                                     _nlpdef=self.mock_nlpdef,
+                                     _destdb=self.mock_db,
+                                     get_table=self.mock_get_table,
+                                     _friendly_name="Fruit",
+                                     create=True):
+
+                starting_fields_values = {}
+
+                self.parser.process(
+                    "Apple Banana Cabbage Dandelion Edelweiss Fig",
+                    starting_fields_values
+                )
+
+        self.mock_values_method.assert_any_call({"fruit": "apple"})
+        self.mock_values_method.assert_any_call({"fruit": "banana"})
+        self.mock_values_method.assert_any_call({"fruit": "fig"})
+        self.assertEqual(self.mock_values_method.call_count, 3)
+        self.assertEqual(self.mock_execute_method.call_count, 3)
+
+        self.mock_notify_transaction_method.assert_any_call(
+            self.mock_session, n_rows=1, n_bytes=sys.getsizeof(
+                {"fruit": "apple"}
+            ),
+            force_commit=mock.ANY
+        )
+        self.mock_notify_transaction_method.assert_any_call(
+            self.mock_session, n_rows=1, n_bytes=sys.getsizeof(
+                {"fruit": "banana"}
+            ),
+            force_commit=mock.ANY
+        )
+        self.mock_notify_transaction_method.assert_any_call(
+            self.mock_session, n_rows=1, n_bytes=sys.getsizeof(
+                {"fruit": "fig"}
+            ),
+            force_commit=mock.ANY
+        )
+        self.assertEqual(self.mock_notify_transaction_method.call_count, 3)
+
+        logger_name = "crate_anon.nlp_manager.base_nlp_parser"
+        self.assertIn(
+            f"DEBUG:{logger_name}:NLP processor fruitdef/Fruit: found 3 values",
+            logging_cm.output
+        )

--- a/crate_anon/nlp_manager/tests/nlp_parser_tests.py
+++ b/crate_anon/nlp_manager/tests/nlp_parser_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-crate_anon/nlp_manager/tests/nlp_manager_tests.py
+crate_anon/nlp_manager/tests/nlp_parser_tests.py
 
 ===============================================================================
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1317,6 +1317,8 @@ Changes
 
 **0.19.2, in progress**
 
+- Handle errors when inserting rows in the destination table during NLP.
+
 ===============================================================================
 
 .. rubric:: Footnotes

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ INSTALL_REQUIRES = [
 
     # Packages for cloud NLP:
     "bcrypt==3.1.7",  # bcrypt encryption
-    "cryptography==3.2.1",  # cryptography library
+    "cryptography==3.3.1",  # cryptography library
     # "mysqlclient",  # database access
     "paste==3.4.2",  # middleware; https://github.com/cdent/paste/
     "pyramid==1.10.4",  # Pyramid web framework


### PR DESCRIPTION
Fixes https://github.com/RudolfCardinal/crate/issues/40

We can't guarantee that the NLP output will be valid for the destination table so handle errors when inserting rows.

This was already being handled for cloud NLP but I've made the error handling consistent so we catch all instances of DatabaseError (OperationalError, DataError etc).
