### PR TITLE
Update various packages to address security issues

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -5,7 +5,7 @@ name: Build
 on:
     push:
         paths:
-            - 'crate_anon/**'
+            - '**.py'
             - .github/workflows/python-checks.yml
 jobs:
     pip-install-and-tests:

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -2,7 +2,11 @@
 # yamllint disable rule:line-length
 name: Build
 # yamllint disable-line rule:truthy
-on: [push]
+on:
+    push:
+        paths:
+            - 'crate_anon/**'
+            - .github/workflows/python-checks.yml
 jobs:
     pip-install-and-tests:
         runs-on: ubuntu-latest

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -35,7 +35,11 @@ jobs:
                   echo installing vulnerability checker
                   python -m pip install safety
                   echo checking packages for vulnerabilities
-                  safety check --full-report
+                  # All of these vulnerabilities look either harmless or very low risk
+                  # 44715 numpy fixed in 1.22 https://github.com/numpy/numpy/issues/19038
+                  # 44716 numpy fixed in 1.22 https://github.com/numpy/numpy/issues/19000
+                  # 44717 numpy fixed in 1.22 https://github.com/numpy/numpy/issues/18993
+                  safety check --full-report -i 44715 -i 44716 -i 44717
                   echo checking python for style and errors
                   flake8 --config=setup.cfg crate_anon
                   echo running tests

--- a/crate_anon/tools/launch_celery.py
+++ b/crate_anon/tools/launch_celery.py
@@ -75,8 +75,8 @@ def inner_main() -> None:
     # os.chdir(DJANGO_ROOT)
     cmdargs = [
         "celery",
-        args.command,
         "-A", CRATEWEB_CELERY_APP_NAME,
+        args.command,
     ]
     if args.command == "worker":
         cmdargs += ["-l", "debug" if args.debug else "info"]  # --loglevel

--- a/docker/dockerfiles/crate.Dockerfile
+++ b/docker/dockerfiles/crate.Dockerfile
@@ -21,7 +21,7 @@
 # FROM: Base image
 # -----------------------------------------------------------------------------
 
-FROM python:3.6-slim-buster
+FROM python:3.7-slim-buster
 # This is a version of Debian 10 (see "cat /etc/debian_version").
 
 

--- a/docker/dockerfiles/crate.Dockerfile
+++ b/docker/dockerfiles/crate.Dockerfile
@@ -95,7 +95,7 @@ WORKDIR /crate
 #
 # - Testing KCL pharmacotherapy app:
 #
-#   export NLPPROGDIR=/crate/venv/lib/python3.6/site-packages/crate_anon/nlp_manager/compiled_nlp_classes/
+#   export NLPPROGDIR=/crate/venv/lib/python3.7/site-packages/crate_anon/nlp_manager/compiled_nlp_classes/
 #   export GATEDIR=/crate/gate
 #   export GATE_PHARMACOTHERAPY_DIR=/crate/brc-gate-pharmacotherapy
 #   export PLUGINFILE=/crate/src/crate_anon/nlp_manager/specimen_gate_plugin_file.ini
@@ -115,7 +115,7 @@ RUN echo "======================================================================
     && export CRATE_SRC="${CRATE_ROOT}/src" \
     && export CRATE_VENV="${CRATE_ROOT}/venv" \
     && export CRATE_VENV_BIN="${CRATE_VENV}/bin" \
-    && export CRATE_PACKAGE_ROOT="${CRATE_VENV}/lib/python3.6/site-packages/crate_anon" \
+    && export CRATE_PACKAGE_ROOT="${CRATE_VENV}/lib/python3.7/site-packages/crate_anon" \
     && export CRATE_GATE_PLUGIN_FILE=${CRATE_PACKAGE_ROOT}/nlp_manager/specimen_gate_plugin_file.ini \
     && export BIOYODIE_DIR="${CRATE_ROOT}/bioyodie" \
     && export GATE_HOME="${CRATE_ROOT}/gate" \

--- a/docker/dockerfiles/docker-compose.yaml
+++ b/docker/dockerfiles/docker-compose.yaml
@@ -218,7 +218,7 @@ services:
 
         environment:
             CRATE_GATE_PLUGIN_FILE: "/crate/src/crate_anon/nlp_manager/specimen_gate_plugin_file.ini"
-            CRATE_PACKAGE_ROOT: "/crate/venv/lib/python3.6/site-packages/crate_anon"
+            CRATE_PACKAGE_ROOT: "/crate/venv/lib/python3.7/site-packages/crate_anon"
             CRATE_WEB_LOCAL_SETTINGS: "/crate/cfg/${CRATE_DOCKER_CRATEWEB_CONFIG_FILENAME}"
             GATE_HOME: "/crate/gate"
             KCL_LEWY_BODY_DIAGNOSIS_DIR: "/crate/kcl_lewy_body_dementia"

--- a/docs/source/installation/installation.rst
+++ b/docs/source/installation/installation.rst
@@ -55,13 +55,13 @@ tools. Here's a logical sequence.
 Python
 ~~~~~~
 
-Install Python 3.6 or higher. If it's not already installed:
+Install Python 3.7 or higher. If it's not already installed:
 
 **Linux**
 
 .. code-block:: bash
 
-    sudo apt-get install python3.6-dev
+    sudo apt-get install python3.7-dev
 
 **Windows**
 
@@ -79,7 +79,7 @@ Choose your own directory names.
 
 .. code-block:: bash
 
-    python3.6 -m venv ~/venvs/crate
+    python3.7 -m venv ~/venvs/crate
     source ~/venvs/crate/bin/activate
     python -m pip install --upgrade pip
     pip install crate-anon

--- a/docs/source/nlp/_nlprp_test_client.py
+++ b/docs/source/nlp/_nlprp_test_client.py
@@ -41,7 +41,7 @@ from requests.auth import HTTPBasicAuth
 from crate_anon.nlprp.api import NlprpRequest, NlprpResponse
 from crate_anon.nlprp.constants import NlprpCommands
 
-assert sys.version_info >= (3, 6), "Need Python 3.6+"
+assert sys.version_info >= (3, 7), "Need Python 3.7+"
 
 log = logging.getLogger(__name__)
 

--- a/docs/source/nlp/_nlprp_test_server.py
+++ b/docs/source/nlp/_nlprp_test_server.py
@@ -44,7 +44,7 @@ from semantic_version import Version
 from crate_anon.nlprp.constants import NlprpKeys
 from crate_anon.nlprp.api import NlprpRequest, NlprpResponse
 
-assert sys.version_info >= (3, 6), "Need Python 3.6+"
+assert sys.version_info >= (3, 7), "Need Python 3.7+"
 
 log = logging.getLogger(__name__)
 

--- a/docs/source/nlp/nlprp.rst
+++ b/docs/source/nlp/nlprp.rst
@@ -1322,7 +1322,7 @@ keys:
       - If true, all queue entries (for this client!) are deleted.
 
 
-Specimen Python 3.6+ client program
+Specimen Python 3.7+ client program
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Very briefly, run ``pip install requests crate_anon``, and then you can run
@@ -1334,7 +1334,7 @@ this:
      :language: python
 
 
-Specimen Python 3.6+ server program
+Specimen Python 3.7+ server program
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Similarly, for a dummy server program, run ``pip install pyramid crate_anon``
@@ -1431,7 +1431,7 @@ The following are implementation details that are at the server's discretion:
 - authentication_
 - authorization_
 - accounting (logging, billing, size/frequency restrictions)
-- containerization, parallel processing, message queue details 
+- containerization, parallel processing, message queue details
 
 
 Abbreviations used in this section

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ INSTALL_REQUIRES = [
     "cherrypy==18.6.0",  # Cross-platform web server
     "colorlog==4.1.0",  # colour in logs
     "distro==1.5.0",  # replaces platform.linux_distribution
-    "django==3.1.13",  # for main CRATE research database web server
+    "django==3.1.14",  # for main CRATE research database web server
     "django-debug-toolbar==3.0a2",  # Django debug toolbar
     # "django-debug-toolbar-template-profiler==2.0.1",  # v1.0.1 removed 2017-01-30: division by zero when rendering time is zero  # noqa
     "django-extensions==3.1.1",  # for graph_models, show_urls etc.

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open(os.path.join(THIS_DIR, "README.rst"), encoding="utf-8") as f:
 
 # Package dependencies
 INSTALL_REQUIRES = [
-    "amqp==5.0.6",  # amqp is used by Celery
+    "amqp==5.0.9",  # amqp is used by Celery
     "appdirs==1.4.4",  # where to store some temporary data
     "arrow==0.15.7",  # [pin exact version from cardinal_pythonlib]
     "beautifulsoup4==4.9.1",  # [pin exact version from cardinal_pythonlib]

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ INSTALL_REQUIRES = [
     "mmh3==2.5.1",  # MurmurHash, for fast non-cryptographic hashing; optionally used by cardinal_pythonlib; requires VC++ under Windows?  # noqa
     "openpyxl==3.0.7",  # read Excel
     "pendulum==2.1.1",  # dates/times
-    "pillow==8.3.2",  # image processing; import as PIL (Python Imaging Library)  # noqa
+    "pillow==9.0.0",  # image processing; import as PIL (Python Imaging Library)  # noqa
     "pdfkit==0.6.1",  # interface to wkhtmltopdf
     "prettytable==0.7.2",  # pretty formating of text-based tables
     "psutil==5.7.2",  # process management

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ INSTALL_REQUIRES = [
     "beautifulsoup4==4.9.1",  # [pin exact version from cardinal_pythonlib]
     "cardinal_pythonlib==1.1.10",  # RNC libraries
     "cairosvg==2.5.1",  # work with SVG files
-    "celery==5.2.0",  # back-end scheduling
+    "celery==5.2.1",  # back-end scheduling
     "chardet==3.0.4",  # character encoding detection for cardinal_pythonlib  # noqa
     "cherrypy==18.6.0",  # Cross-platform web server
     "colorlog==4.1.0",  # colour in logs

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ INSTALL_REQUIRES = [
     "pyparsing==2.4.7",  # generic grammar parser
     "PyPDF2==1.26.0",  # [pin exact version from cardinal_pythonlib]
     "pytest==6.0.2",  # automatic testing
-    "pytz==2020.1",  # timezones
+    "pytz==2021.3",  # timezones
     "python-dateutil==2.8.1",  # [pin exact version from cardinal_pythonlib]
     # "python-docx==0.8.10",  # needs lxml, which has Visual C++ dependencies under Windows  # noqa
     # ... https://python-docx.readthedocs.org/en/latest/user/install.html

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ INSTALL_REQUIRES = [
     "beautifulsoup4==4.9.1",  # [pin exact version from cardinal_pythonlib]
     "cardinal_pythonlib==1.1.10",  # RNC libraries
     "cairosvg==2.5.1",  # work with SVG files
-    "celery==5.2.1",  # back-end scheduling
+    "celery==5.2.3",  # back-end scheduling
     "chardet==3.0.4",  # character encoding detection for cardinal_pythonlib  # noqa
     "cherrypy==18.6.0",  # Cross-platform web server
     "colorlog==4.1.0",  # colour in logs

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ INSTALL_REQUIRES = [
     "django-sslserver==0.22",  # SSL development server for Django
     "flake8==3.8.4",  # code checks
     "flashtext==2.7",  # fast word replacement with the FlashText algorithm
-    "flower==0.9.5",  # debug Celery; web server; only runs explicitly
+    "flower==1.0.0",  # debug Celery; web server; only runs explicitly
     "fuzzy==1.2.2",  # phonetic matching
     "gunicorn==20.0.4",  # UNIX only, though will install under Windows
     "kombu==5.2.2",  # AMQP library for Celery; requires VC++ under Windows

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ INSTALL_REQUIRES = [
     "cherrypy==18.6.0",  # Cross-platform web server
     "colorlog==4.1.0",  # colour in logs
     "distro==1.5.0",  # replaces platform.linux_distribution
-    "django==3.1.14",  # for main CRATE research database web server
+    "django==3.2.12",  # for main CRATE research database web server
     "django-debug-toolbar==3.0a2",  # Django debug toolbar
     # "django-debug-toolbar-template-profiler==2.0.1",  # v1.0.1 removed 2017-01-30: division by zero when rendering time is zero  # noqa
     "django-extensions==3.1.1",  # for graph_models, show_urls etc.

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ INSTALL_REQUIRES = [
     "flower==1.0.0",  # debug Celery; web server; only runs explicitly
     "fuzzy==1.2.2",  # phonetic matching
     "gunicorn==20.0.4",  # UNIX only, though will install under Windows
-    "kombu==5.2.2",  # AMQP library for Celery; requires VC++ under Windows
+    "kombu==5.2.3",  # AMQP library for Celery; requires VC++ under Windows
     "mako==1.1.3",  # templates with Python in
     "MarkupSafe==1.1.1",  # for HTML escaping
     # mmh3 requires VC++

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open(os.path.join(THIS_DIR, "README.rst"), encoding="utf-8") as f:
 
 # Package dependencies
 INSTALL_REQUIRES = [
-    "amqp==2.6.0",  # amqp is used by Celery
+    "amqp==5.0.6",  # amqp is used by Celery
     "appdirs==1.4.4",  # where to store some temporary data
     "arrow==0.15.7",  # [pin exact version from cardinal_pythonlib]
     "beautifulsoup4==4.9.1",  # [pin exact version from cardinal_pythonlib]
@@ -89,7 +89,7 @@ INSTALL_REQUIRES = [
     "flower==0.9.5",  # debug Celery; web server; only runs explicitly
     "fuzzy==1.2.2",  # phonetic matching
     "gunicorn==20.0.4",  # UNIX only, though will install under Windows
-    "kombu==5.2.1",  # AMQP library for Celery; requires VC++ under Windows
+    "kombu==5.2.2",  # AMQP library for Celery; requires VC++ under Windows
     "mako==1.1.3",  # templates with Python in
     "MarkupSafe==1.1.1",  # for HTML escaping
     # mmh3 requires VC++

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ INSTALL_REQUIRES = [
     "beautifulsoup4==4.9.1",  # [pin exact version from cardinal_pythonlib]
     "cardinal_pythonlib==1.1.10",  # RNC libraries
     "cairosvg==2.5.1",  # work with SVG files
-    "celery==4.4.6",  # back-end scheduling
+    "celery==5.2.0",  # back-end scheduling
     "chardet==3.0.4",  # character encoding detection for cardinal_pythonlib  # noqa
     "cherrypy==18.6.0",  # Cross-platform web server
     "colorlog==4.1.0",  # colour in logs
@@ -89,7 +89,7 @@ INSTALL_REQUIRES = [
     "flower==0.9.5",  # debug Celery; web server; only runs explicitly
     "fuzzy==1.2.2",  # phonetic matching
     "gunicorn==20.0.4",  # UNIX only, though will install under Windows
-    "kombu==4.6.11",  # AMQP library for Celery; requires VC++ under Windows
+    "kombu==5.2.1",  # AMQP library for Celery; requires VC++ under Windows
     "mako==1.1.3",  # templates with Python in
     "MarkupSafe==1.1.1",  # for HTML escaping
     # mmh3 requires VC++


### PR DESCRIPTION
Also Python >= 3.7 everywhere
Ignoring numpy <1.22 safety warnings for now - they look harmless.
 
I've checked the Django 3.2 and Pillow 9.0 release notes and couldn't see any incompatible changes that apply to us. 

Changes cherry-picked from the docker-dev branch.
