### PR TITLE
Fix docs build

### DIFF
--- a/crate_anon/linkage/constants.py
+++ b/crate_anon/linkage/constants.py
@@ -191,7 +191,10 @@ class FuzzyDefaults:
 
     # Public data that we provide a local copy of
     _THIS_DIR = os.path.abspath(os.path.dirname(__file__))
-    _DATA_DIR = os.path.join(_THIS_DIR, "data")
+    if EnvVar.GENERATING_CRATE_DOCS in os.environ:
+        _DATA_DIR = "/path/to/linkage/data/"
+    else:
+        _DATA_DIR = os.path.join(_THIS_DIR, "data")
     FORENAME_SEX_FREQ_CSV = os.path.join(_DATA_DIR, "us_forename_sex_freq.zip")
     SURNAME_FREQ_CSV = os.path.join(_DATA_DIR, "us_surname_freq.zip")
     POSTCODES_CSV = os.path.join(_DATA_DIR, "ONSPD_MAY_2022_UK.zip")
@@ -296,7 +299,7 @@ class FuzzyDefaults:
 
         avg_people_per_household = 2.4
         n_people_per_homeless_household = (2 / 3) * 1 + (1 / 3) * avg_people_per_household
-        n_people_homeless_england = (11.4 / 100) * 68180 * n_people_per_homeless_household 
+        n_people_homeless_england = (11.4 / 100) * 68180 * n_people_per_homeless_household
         n_people_uk = 27.8e6 * 2.4  # 66.7 million, so that's about right
         n_people_england = 0.843 * n_people_uk
         p_homeless = n_people_homeless_england / n_people_england
@@ -338,7 +341,7 @@ class FuzzyDefaults:
     sector probability will exactly match the unit probability) and any
     inadvertent sector-not-unit match will give a log likelihood of +∞ and a
     certain match.
-    
+
     However, empirically in SystmOne, ZZ993 / ZZ993VZ = 1.83 (see paper).
 
     """  # noqa

--- a/crate_anon/linkage/helpers.py
+++ b/crate_anon/linkage/helpers.py
@@ -680,7 +680,7 @@ def getdictval(
     The key must be in the dictionary, and the value must be non-blank.
     - The value must be of type `type_`, or ``None`` if
     - If ``mandatory`` is True, the key must be present (and if a string,
-      the value must be non-blank).
+    the value must be non-blank).
     - Otherwise, if absent, ``default`` is returned.
     The default is non-mandatory and returning None.
     """

--- a/crate_anon/linkage/helpers.py
+++ b/crate_anon/linkage/helpers.py
@@ -676,13 +676,12 @@ def getdictval(
     default: Any = None,
 ) -> Any:
     """
-    Returns a value from a dictionary or raises an exception.
-    The key must be in the dictionary, and the value must be non-blank.
-    - The value must be of type `type_`, or ``None`` if
-    - If ``mandatory`` is True, the key must be present (and if a string,
-    the value must be non-blank).
-    - Otherwise, if absent, ``default`` is returned.
-    The default is non-mandatory and returning None.
+    Returns a value from a dictionary, or raises ValueError.
+
+    - If ``mandatory`` is True, the key must be present, and the value must not
+      be ``None`` or a blank string.
+    - If ``mandatory`` is False and the key is absent, ``default`` is returned.
+    - The value must be of type `type_` (or ``None`` if permitted).
     """
     try:
         v = d[key]

--- a/docs/recreate_inclusion_files.py
+++ b/docs/recreate_inclusion_files.py
@@ -115,38 +115,27 @@ def run_cmd(
 # =============================================================================
 
 
-def get_bash_completion_commands(
-    prefix: str, encoding: str = DEFAULT_ENCODING
-) -> List[str]:
+def get_scripts_with_prefix(prefix: str) -> List[str]:
     """
-    Get available commands starting with the prefix.
-    Roughly equivalent to typing the prefix, then pressing Tab in Bash.
-    See
-
-    - https://unix.stackexchange.com/questions/151118/understand-compgen-builtin-command
-    - https://stackoverflow.com/questions/5460923/run-bash-built-in-commands-in-python
+    Get available scripts starting with the prefix.
 
     Args:
         prefix:
-            Command prefix.
-        encoding:
-            Encoding to use.
+            Script prefix.
 
     Returns:
-        A sorted list of possible commands.
-    """  # noqa
-    subcommand = " ".join(
-        ["compgen", "-c", prefix]  # bash built-in  # list possible commands
-    )
-    output = subprocess.check_output(
+        A sorted list of possible scripts.
+    """
+
+    import pkg_resources
+
+    return sorted(
         [
-            "bash",  # fire up bash
-            "-c",  # and run the next (single string!) argument as a command:
-            subcommand,
+            ep.name
+            for ep in pkg_resources.iter_entry_points("console_scripts")
+            if ep.name.startswith(prefix)
         ]
-    ).decode(encoding)
-    possibilities = sorted(filter(None, output.split("\n")))
-    return possibilities
+    )
 
 
 def make_command_line_index_help(filename: str) -> None:
@@ -158,7 +147,7 @@ def make_command_line_index_help(filename: str) -> None:
     each command.
     """
     # Get all possible CRATE-related commands:
-    commands = get_bash_completion_commands("crate_")
+    commands = get_scripts_with_prefix("crate_")
     commands_text = ""
     for c in commands:
         commands_text += f"""

--- a/docs/source/autodoc_extra/_command_line_index.rst
+++ b/docs/source/autodoc_extra/_command_line_index.rst
@@ -29,10 +29,6 @@ Index of CRATE commands
 
 :ref:`crate_anon_summarize_dd <crate_anon_summarize_dd>`
 
-:ref:`crate_anon_web_create_private_settings <crate_anon_web_create_private_settings>`
-
-:ref:`crate_anon_web_django_manage <crate_anon_web_django_manage>`
-
 :ref:`crate_anonymise <crate_anonymise>`
 
 :ref:`crate_anonymise_multiprocess <crate_anonymise_multiprocess>`

--- a/docs/source/linkage/_crate_fuzzy_id_match_help.txt
+++ b/docs/source/linkage/_crate_fuzzy_id_match_help.txt
@@ -150,9 +150,8 @@ Frequency information for prior probabilities:
                         forenames. You can generate one via
                         crate_fetch_wordlists. [Information saved in the
                         forename cache. If you change this, delete your
-                        forename cache.] (default: /home/rudolf/Documents/code
-                        /crate/crate_anon/linkage/data/us_forename_sex_freq.zi
-                        p)
+                        forename cache.] (default:
+                        /path/to/linkage/data/us_forename_sex_freq.zip)
   --forename_min_frequency FORENAME_MIN_FREQUENCY
                         Minimum frequency for forenames. If a frequency is
                         unknown or less than this, the software uses this
@@ -169,9 +168,8 @@ Frequency information for prior probabilities:
                         CSV file of "name, frequency" pairs for surnames. You
                         can generate one via crate_fetch_wordlists.
                         [Information saved in the surname cache. If you change
-                        this, delete your surname cache.] (default: /home/rudo
-                        lf/Documents/code/crate/crate_anon/linkage/data/us_sur
-                        name_freq.zip)
+                        this, delete your surname cache.] (default:
+                        /path/to/linkage/data/us_surname_freq.zip)
   --surname_min_frequency SURNAME_MIN_FREQUENCY
                         Minimum frequency for surnames. If a frequency is
                         unknown or less than this, the software uses this
@@ -216,9 +214,8 @@ Frequency information for prior probabilities:
                         CSV file of postcode geography from UK Census/ONS
                         data. A ZIP file is also acceptable. [Information
                         saved in the postcode cache. If you change this,
-                        delete your postcode cache.] (default: /home/rudolf/Do
-                        cuments/code/crate/crate_anon/linkage/data/ONSPD_MAY_2
-                        022_UK.zip)
+                        delete your postcode cache.] (default:
+                        /path/to/linkage/data/ONSPD_MAY_2022_UK.zip)
   --k_postcode K_POSTCODE
                         Probability multiple: P[P(postcode unit match | ¬H)] =
                         k_postcode * f_f_postcode[national unit fraction], and
@@ -491,9 +488,8 @@ Frequency information for prior probabilities:
                         forenames. You can generate one via
                         crate_fetch_wordlists. [Information saved in the
                         forename cache. If you change this, delete your
-                        forename cache.] (default: /home/rudolf/Documents/code
-                        /crate/crate_anon/linkage/data/us_forename_sex_freq.zi
-                        p)
+                        forename cache.] (default:
+                        /path/to/linkage/data/us_forename_sex_freq.zip)
   --forename_min_frequency FORENAME_MIN_FREQUENCY
                         Minimum frequency for forenames. If a frequency is
                         unknown or less than this, the software uses this
@@ -510,9 +506,8 @@ Frequency information for prior probabilities:
                         CSV file of "name, frequency" pairs for surnames. You
                         can generate one via crate_fetch_wordlists.
                         [Information saved in the surname cache. If you change
-                        this, delete your surname cache.] (default: /home/rudo
-                        lf/Documents/code/crate/crate_anon/linkage/data/us_sur
-                        name_freq.zip)
+                        this, delete your surname cache.] (default:
+                        /path/to/linkage/data/us_surname_freq.zip)
   --surname_min_frequency SURNAME_MIN_FREQUENCY
                         Minimum frequency for surnames. If a frequency is
                         unknown or less than this, the software uses this
@@ -557,9 +552,8 @@ Frequency information for prior probabilities:
                         CSV file of postcode geography from UK Census/ONS
                         data. A ZIP file is also acceptable. [Information
                         saved in the postcode cache. If you change this,
-                        delete your postcode cache.] (default: /home/rudolf/Do
-                        cuments/code/crate/crate_anon/linkage/data/ONSPD_MAY_2
-                        022_UK.zip)
+                        delete your postcode cache.] (default:
+                        /path/to/linkage/data/ONSPD_MAY_2022_UK.zip)
   --k_postcode K_POSTCODE
                         Probability multiple: P[P(postcode unit match | ¬H)] =
                         k_postcode * f_f_postcode[national unit fraction], and
@@ -807,9 +801,8 @@ Frequency information for prior probabilities:
                         forenames. You can generate one via
                         crate_fetch_wordlists. [Information saved in the
                         forename cache. If you change this, delete your
-                        forename cache.] (default: /home/rudolf/Documents/code
-                        /crate/crate_anon/linkage/data/us_forename_sex_freq.zi
-                        p)
+                        forename cache.] (default:
+                        /path/to/linkage/data/us_forename_sex_freq.zip)
   --forename_min_frequency FORENAME_MIN_FREQUENCY
                         Minimum frequency for forenames. If a frequency is
                         unknown or less than this, the software uses this
@@ -826,9 +819,8 @@ Frequency information for prior probabilities:
                         CSV file of "name, frequency" pairs for surnames. You
                         can generate one via crate_fetch_wordlists.
                         [Information saved in the surname cache. If you change
-                        this, delete your surname cache.] (default: /home/rudo
-                        lf/Documents/code/crate/crate_anon/linkage/data/us_sur
-                        name_freq.zip)
+                        this, delete your surname cache.] (default:
+                        /path/to/linkage/data/us_surname_freq.zip)
   --surname_min_frequency SURNAME_MIN_FREQUENCY
                         Minimum frequency for surnames. If a frequency is
                         unknown or less than this, the software uses this
@@ -873,9 +865,8 @@ Frequency information for prior probabilities:
                         CSV file of postcode geography from UK Census/ONS
                         data. A ZIP file is also acceptable. [Information
                         saved in the postcode cache. If you change this,
-                        delete your postcode cache.] (default: /home/rudolf/Do
-                        cuments/code/crate/crate_anon/linkage/data/ONSPD_MAY_2
-                        022_UK.zip)
+                        delete your postcode cache.] (default:
+                        /path/to/linkage/data/ONSPD_MAY_2022_UK.zip)
   --k_postcode K_POSTCODE
                         Probability multiple: P[P(postcode unit match | ¬H)] =
                         k_postcode * f_f_postcode[national unit fraction], and
@@ -1163,9 +1154,8 @@ Frequency information for prior probabilities:
                         forenames. You can generate one via
                         crate_fetch_wordlists. [Information saved in the
                         forename cache. If you change this, delete your
-                        forename cache.] (default: /home/rudolf/Documents/code
-                        /crate/crate_anon/linkage/data/us_forename_sex_freq.zi
-                        p)
+                        forename cache.] (default:
+                        /path/to/linkage/data/us_forename_sex_freq.zip)
   --forename_min_frequency FORENAME_MIN_FREQUENCY
                         Minimum frequency for forenames. If a frequency is
                         unknown or less than this, the software uses this
@@ -1182,9 +1172,8 @@ Frequency information for prior probabilities:
                         CSV file of "name, frequency" pairs for surnames. You
                         can generate one via crate_fetch_wordlists.
                         [Information saved in the surname cache. If you change
-                        this, delete your surname cache.] (default: /home/rudo
-                        lf/Documents/code/crate/crate_anon/linkage/data/us_sur
-                        name_freq.zip)
+                        this, delete your surname cache.] (default:
+                        /path/to/linkage/data/us_surname_freq.zip)
   --surname_min_frequency SURNAME_MIN_FREQUENCY
                         Minimum frequency for surnames. If a frequency is
                         unknown or less than this, the software uses this
@@ -1229,9 +1218,8 @@ Frequency information for prior probabilities:
                         CSV file of postcode geography from UK Census/ONS
                         data. A ZIP file is also acceptable. [Information
                         saved in the postcode cache. If you change this,
-                        delete your postcode cache.] (default: /home/rudolf/Do
-                        cuments/code/crate/crate_anon/linkage/data/ONSPD_MAY_2
-                        022_UK.zip)
+                        delete your postcode cache.] (default:
+                        /path/to/linkage/data/ONSPD_MAY_2022_UK.zip)
   --k_postcode K_POSTCODE
                         Probability multiple: P[P(postcode unit match | ¬H)] =
                         k_postcode * f_f_postcode[national unit fraction], and

--- a/github_action_scripts/build_docs.sh
+++ b/github_action_scripts/build_docs.sh
@@ -4,6 +4,8 @@
 # Rebuild Sphinx docs from scratch and check generated files match those checked
 # in
 
+set -eux -o pipefail
+
 sudo apt-get install texlive-latex-extra dvipng
 python -m venv "${HOME}/venv"
 source "${HOME}/venv/bin/activate"


### PR DESCRIPTION
In 0784848f476ae9eb101d430d32385a088db1bb68 I inadvertently removed the stop-on-failure line from the GitHub action script to rebuild the docs. It was failing but the script was carnying on regardless and we weren't alerted to it.

This PR reinstates the line and fixes some problems with the docs build, namely:
* Bad indentation in a comment block
* Paths to defaults in the fuzzy matching help file
* Detection of `crate_` commands, which was picking up anything on the user's path, not just in the python packages.
